### PR TITLE
Rename some portions of the spec.

### DIFF
--- a/Documents/FileSystemSpec.md
+++ b/Documents/FileSystemSpec.md
@@ -10,6 +10,11 @@ This document details a solution to creating virtual file systems in a platform 
         - [Basic Structures](#basicStructures)
         - [Capabilities](#capabilities)
         - [Requests and Notifications](#requestsAndNotifications)
+    - [Examples](#examples)
+        - [External file population](#populationExample)
+        - [Language service handling changes](#handlingChangesExample)
+        - [Getting content for dynamic files](#dynamicContentExample)
+        - [Embedded language feature interaction](#embeddedFeatureExample)
 
 # <a href="#problemBackground" name="problemBackground">Problem Background</a>
 
@@ -598,3 +603,33 @@ export interface RenameFileOptions {
 _Response:_
 - result: void
 - error: code and message set in case an exception during the `fileSystem/rename` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
+
+### <a href="#examples" name="examples">Examples</a>
+
+The following examples attempt to illustrate common interactions with a virtual file system
+
+#### <a href="#populationExample" name="populationExample" class="anchor">External file population</a>
+
+*Disclaimer: I'm not entirely sure this makes sense to populate a file system in an indirect way like this. Alternatively it'd probably make sense for the project system to have in-proc providers for various project systems and use the virtual file system as the standard representation for others to interact with.*
+
+Here's what it could look like if there were individual project system servers that populated the web project system. This example is of a Blazor project system spinning up. On incomplete project understanding the system recognizes files on disk and adds them to the web:// virtual file system. Once project references have been resolved a Razor class library includes static content which overrides site.css and adds a library.css file to the expected wwwwroot entries.
+
+![image](https://user-images.githubusercontent.com/2008729/154003595-2b50949a-9773-4127-8155-9d9d1c2cb3be.png)
+
+#### <a href="#handlingChangesExample" name="handlingChangesExample" class="anchor">Language service handling changes</a>
+
+This example assumes the file system has been populated as in the [previous example](#populationExample). On incomplete project understanding the system recognizes files on disk and adds them to the web:// virtual file system. Notifications for these changes are propagated to language services who then read their content to derive language services (i.e. css class completion). Once project references have been resolved a Razor class library includes static content which overrides site.css and adds a library.css file to the expected wwwwroot entries.
+
+![image](https://user-images.githubusercontent.com/2008729/154004455-ef15a8f2-0f7b-4fd8-9952-26c2fe0173e1.png)
+
+#### <a href="#dynamicContentExample" name="dynamicContentExample" class="anchor">Getting content for dynamic files</a>
+
+User goes to definition on a `System.Diagnostics.Debug` type. The type is represented in metadata and therefore doesn't exist on disk. Therefore because the C# language server indicated it can provide content for the `dynamic-csharp` URI scheme the client then asks the C# language server for the appropriate file content.
+
+![image](https://user-images.githubusercontent.com/2008729/154006408-85f16dfe-d829-4430-8ba1-b06afb9b8774.png)
+
+#### <a href="#embeddedFeatureExample" name="embeddedFeatureExample" class="anchor">Embedded language feature interaction</a>
+
+Here's an example in Razor (C# / HTML are sub-languages) where a user opens a file, types an `@` and then closes the file (`@` transitions into C#). It represents what happens for the C# embedded language (excludes the HTML embedded language for simplicity).
+
+![image](https://user-images.githubusercontent.com/2008729/154007241-2adc4cf7-cb2d-4bf2-bb47-407f272c56b7.png)

--- a/Documents/FileSystemSpec.md
+++ b/Documents/FileSystemSpec.md
@@ -141,12 +141,12 @@ export interface FileSystemProviderOptions {
     /**
      * Whether or not the file system is case sensitive.
      */
-    isCaseSensitive?: boolean;
+    caseSensitive?: boolean;
 
     /**
      * Whether or not the file system is readonly.
      */
-    isReadonly?: boolean
+    readonly?: boolean
 }
 ```
 
@@ -225,20 +225,20 @@ export namespace FileChangeType {
 }
 ```
 
-#### <a href="#watch" name="watch" class="anchor">Watch Notification (:arrow_right:)</a>
+#### <a href="#startWatching" name="startWatching" class="anchor">StartWatching Notification (:arrow_right:)</a>
 
-Watch requests are sent from the client to the server to subscribe to [DidChangeFile](#didChangeFile) events in the file or folder denoted by `uri`.
+Start watching notifications are sent from the client to the server to subscribe to [DidChangeFile](#didChangeFile) events in the file or folder denoted by `uri`.
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
 _Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
 
 _Notification:_
-- method: `fileSystem/watch`
+- method: `fileSystem/startWatching`
 - params: `WatchParams` defined as follows:
 
 ```typescript
-export interface WatchParams {
+export interface StartWatchingParams {
     /**
      * The uri of the file or folder to be watched.
      */
@@ -270,7 +270,7 @@ export interface WatchFileOptions {
 
 #### <a href="#stopWatching" name="stopWatching" class="anchor">StopWatching Notification (:arrow_right:)</a>
 
-A notification sent from client to server to unsubscribe from a watched file or folder.
+Stop watching notifications are sent from client to server to unsubscribe from a watched file or folder.
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -282,7 +282,7 @@ _Notification:_
 
 ```typescript
 /**
- * A notification to signal an unsubscribe from a corresponding [watch](#watch) request.
+ * A notification to signal an unsubscribe from a corresponding [start watching](#startWatching) request.
  */
 export interface StopWatchingParams {
     /**

--- a/Documents/FileSystemSpec.md
+++ b/Documents/FileSystemSpec.md
@@ -120,6 +120,10 @@ export namespace FileSystemErrorType {
  * Client capabilities specific to file system providers
  */
 export interface FileSystemProviderClientCapabilities {
+    /**
+     * Whether or not the file system features are queryable.
+     */
+    queryable?: boolean;
 }
 ```
 
@@ -159,9 +163,9 @@ export interface FileSystemProviderRegistrationOptions extends FileSystemProvide
 
 ### <a href="#requestsAndNotifications" name="requestsAndNotifications">Requests and Notifications</a>
 
-#### <a href="#didChangeFile" name="didChangeFile" class="anchor">DidChangeFile Notification (:arrow_left:)</a>
+#### <a href="#didChangeFile" name="didChangeFile" class="anchor">DidChangeFile Notification (:arrow_left: or :arrow_right:)</a>
 
-Change file notifications are sent from the server to the client to signal the change of the registered file system provider.
+Change file notifications are sent from the server to the client or client to server to signal the change of the registered file system provider.
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -225,9 +229,9 @@ export namespace FileChangeType {
 }
 ```
 
-#### <a href="#startWatching" name="startWatching" class="anchor">StartWatching Notification (:arrow_right:)</a>
+#### <a href="#startWatching" name="startWatching" class="anchor">StartWatching Notification (:arrow_right: or :arrow_left:)</a>
 
-Start watching notifications are sent from the client to the server to subscribe to [DidChangeFile](#didChangeFile) events in the file or folder denoted by `uri`.
+Start watching notifications are sent from the client to the server or server to client to subscribe to [DidChangeFile](#didChangeFile) events in the file or folder denoted by `uri`.
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -268,9 +272,9 @@ export interface WatchFileOptions {
 }
 ```
 
-#### <a href="#stopWatching" name="stopWatching" class="anchor">StopWatching Notification (:arrow_right:)</a>
+#### <a href="#stopWatching" name="stopWatching" class="anchor">StopWatching Notification (:arrow_right: or :arrow_left:)</a>
 
-Stop watching notifications are sent from client to server to unsubscribe from a watched file or folder.
+Stop watching notifications are sent from client to server or server to client to unsubscribe from a watched file or folder.
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -292,9 +296,9 @@ export interface StopWatchingParams {
 }
 ```
 
-#### <a href="#stat" name="stat" class="anchor">Stat Request (:arrow_right_hook:)</a>
+#### <a href="#stat" name="stat" class="anchor">Stat Request (:leftwards_arrow_with_hook: or :arrow_right_hook:)</a>
 
-Stat requests are sent from the client to the server to request metadata about a URI.
+Stat requests are sent from the client to the server or server to client to request metadata about a URI.
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -352,9 +356,9 @@ export interface FileStatResponse {
 }
 ```
 
-#### <a href="#readDirectory" name="readDirectory" class="anchor">ReadDirectory Request (:arrow_right_hook:)</a>
+#### <a href="#readDirectory" name="readDirectory" class="anchor">ReadDirectory Request (:leftwards_arrow_with_hook: or :arrow_right_hook:)</a>
 
-Read directory requests are sent from the client to the server to retrieve all entries of a directory.
+Read directory requests are sent from the client to the server or server to client to retrieve all entries of a directory.
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -402,9 +406,11 @@ export interface DirectoryChild {
 }
 ```
 
-#### <a href="#createDirectory" name="createDirectory" class="anchor">CreateDirectory Request (:arrow_right_hook:)</a>
+#### <a href="#createDirectory" name="createDirectory" class="anchor">CreateDirectory Request (:leftwards_arrow_with_hook:)</a>
 
 Create directory requests are sent from the client to the server to create a new directory.
+
+*Note: If a server wants to request a directory be created it can do so via [`workspace/applyEdit`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit) requests. This request does not respect the `queryable` client capability property.*
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -427,9 +433,9 @@ _Response:_
 - result: void
 - error: code and message set in case an exception during the `fileSystem/createDirectory` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
 
-#### <a href="#readFile" name="readFile" class="anchor">ReadFile Request (:arrow_right_hook:)</a>
+#### <a href="#readFile" name="readFile" class="anchor">ReadFile Request (:leftwards_arrow_with_hook: or :arrow_right_hook:)</a>
 
-Read file requests are sent from the client to the server to retrieve the content of a file.
+Read file requests are sent from the client to the server or server to client to retrieve the content of a file.
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -461,9 +467,11 @@ export interface ReadFileResponse {
 }
 ```
 
-#### <a href="#writeFile" name="writeFile" class="anchor">WriteFile Request (:arrow_right_hook:)</a>
+#### <a href="#writeFile" name="writeFile" class="anchor">WriteFile Request (:leftwards_arrow_with_hook:)</a>
 
-Write file requests are sent from the client to the server to write data to a file, replacing its entire contents.
+Write file requests are sent from the client to the server or from server to client to write data to a file, replacing its entire contents.
+
+*Note: If a server wants to request a file be created it can do so via [`workspace/applyEdit`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit) requests. This request does not respect the `queryable` client capability property.*
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -508,9 +516,11 @@ _Response:_
 - result: void
 - error: code and message set in case an exception during the `fileSystem/writeFile` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
 
-#### <a href="#delete" name="delete" class="anchor">Delete Request (:arrow_right_hook:)</a>
+#### <a href="#delete" name="delete" class="anchor">Delete Request (:leftwards_arrow_with_hook:)</a>
 
 Delete requests are sent from the client to the server to delete a file or folder.
+
+*Note: If a server wants to request a file or folder be deleted it can do so via [`workspace/applyEdit`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit) requests. This request does not respect the `queryable` client capability property.*
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 
@@ -545,9 +555,11 @@ _Response:_
 - result: void
 - error: code and message set in case an exception during the `fileSystem/delete` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
 
-#### <a href="#rename" name="rename" class="anchor">Rename Request (:arrow_right_hook:)</a>
+#### <a href="#rename" name="rename" class="anchor">Rename Request (:leftwards_arrow_with_hook:)</a>
 
 Rename requests are sent from the client to the server to rename a file or folder.
+
+*Note: If a server wants to request a file or folder be renamed it can do so via [`workspace/applyEdit`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit) requests. This request does not respect the `queryable` client capability property.*
 
 _Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
 


### PR DESCRIPTION
- Request / paramater renames: `fileSystem/watch` => `fileSystem/startWatching` and `WatchParams` => `StartWatchingParams`
- Capability renames: `isCaseSensitive` => `caseSensitive` and `isReadonly` => `readonly`

/cc @jimmylewis